### PR TITLE
Change namespace from 'app' to 'dokku'

### DIFF
--- a/commands
+++ b/commands
@@ -38,7 +38,7 @@ case "$1" in
   opencv:install)
 
 	APP="$2"
-	IMAGE="app/$APP"
+	IMAGE="dokku/$APP"
 
 	echo "-----> Injecting OpenCV in $APP"
 


### PR DESCRIPTION
Since Dokku 0.10.0 the app namespace is called `dokku`.
See https://github.com/progrium/dokku/issues/533
